### PR TITLE
Add agenda collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ You are welcome to play with the code and attempt to use it, but most users shou
 - [ ] Add toml config
   - [ ] top level config object should be a site
   - [ ] paths for time intervals should be configurable
+  - [ ] agenda page size
+  - [ ] agenda start date
 - [X] ~~*Add [tera](https://lib.rs/crates/tera) templates*~~ [2022-05-17]
 - [ ] Add call to get first X day of the month
 - [X] ~~*Add call to get date of the first day of the week*~~ [2022-05-19]
 - [ ] Output html pages
   - [ ] event detail
-  - [ ] agenda (list of events)
+  - [X] agenda (list of events)
   - [ ] day
   - [X] ~~*week*~~ [2022-05-19]
   - [ ] month

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,5 +25,9 @@ fn main() -> eyre::Result<()> {
         // TODO take the output path from the config
         .create_day_pages(&PathBuf::from("output/day"))?;
 
+    calendar_collection
+        // TODO take the output path from the config
+        .create_agenda_pages(&PathBuf::from("output/agenda"))?;
+
     Ok(())
 }

--- a/templates/agenda.html
+++ b/templates/agenda.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../public/statical.css" />
+    <title>Agenda View</title>
+  </head>
+  <body>
+    <div class="calendar">
+      <h1>Events</h1>
+      <div class="pagination">
+        <div class="previous"><a href="{{ previous_file_name }}">&lt; Previous</a></div>
+        <div class="next"><a href="{{ next_file_name }}">Next &gt;</a></div>
+      </div>
+      {% for event in events %}
+      <p>{{ event[0].date }} {{ event[0].events[0].start }} - {{ event[1].summary }}</p>
+      {% endfor %}
+      <pre>{{ __tera_context }}</pre>
+      <div class="pagination">
+        <div class="previous"><a href="{{ previous_file_name }}">&lt; Previous</a></div>
+        <div class="next"><a href="{{ next_file_name }}">Next &gt;</a></div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a simple agenda collection, listing all events in size-limited pages, the present day being on page 0, future events on positive-numbered pages and past events on negative-numbered pages.

For now, page size is hardcoded and origin time is runtime's now.

I needed exactly this tool (precisely the agenda feature) for my website, and fortunately I found this project before starting writing a new one (which would have been very similar)!